### PR TITLE
use ensureDir

### DIFF
--- a/magiccap/app.js
+++ b/magiccap/app.js
@@ -6,7 +6,7 @@ const sqlite3 = require("sqlite3").verbose();
 let captureDatabase = global.captureDatabase = new sqlite3.Database(`${require("os").homedir()}/magiccap_captures.db`);
 // Defines the capture database.
 
-const { stat, writeJSON, mkdir, readdir, readFile } = require("fs-nextra");
+const { stat, writeJSON, ensureDir, readdir, readFile } = require("fs-nextra");
 const capture = require(`${__dirname}/capture.js`);
 const { app, Tray, Menu, dialog, globalShortcut, BrowserWindow, ipcMain, clipboard } = require("electron");
 const notifier = require("node-notifier");
@@ -98,7 +98,7 @@ async function getDefaultConfig() {
 		save_capture: true,
 		save_path: pics_dir,
 	};
-	await mkdir(config.save_path).catch(async error => {
+	await ensureDir(config.save_path).catch(async error => {
 		if (!(error.errno === -4075 || error.errno === -17)) {
 			config.Remove("save_path");
 		}


### PR DESCRIPTION
The given directory by electron on `getPath` can be non-existing.

[`ensureDir` recursively makes directories until the given path exists](https://fs-nextra.js.org/fsn_nextra.html#.ensureDir__anchor), so it should fix the edge-case.

The PR probably doesn't work because `ensureDir` is in a separate namespace inside `fs-nextra`, and due to #62, I'm unable to run a build off the modified code. Feel free to close and make a proper fix.